### PR TITLE
Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/check_dhcp

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+
+BINS=check_dhcp
+
+all: $(BINS)
+clean:
+	rm -f $(BINS)
+
+check_dhcp: check_dhcp.c
+	gcc -o $@ $+
+


### PR DESCRIPTION
Makefile hinzugefügt, um check_dhcp zu bauen.

@jplitza: sind da noch weitere GCC-Optionen nötig, um das korrekt zu bauen? Ich habs mit dem Makefile bauen können, aber Tests gingen nicht, weil hier schon ein dhclient läuft.
