### PR TITLE
Archlinux support

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,0 +1,25 @@
+pkgbase = gatemon-git
+	pkgver = r37.615d977
+	pkgrel = 1
+	url = https://github.com/FreifunkBremen/gatemon
+	arch = any
+	license = GPL3
+	depends = monitoring-plugins
+	depends = bind-tools
+	depends = ndisc6
+	backup = etc/check-all-vpn-exits.cfg
+	source = check-all-vpn-exits.cfg
+	source = check-all-vpn-exits.sh
+	source = check-all-vpn-exits.service
+	source = check-all-vpn-exits.timer
+	source = Makefile
+	source = check_dhcp.c
+	sha256sums = SKIP
+	sha256sums = SKIP
+	sha256sums = SKIP
+	sha256sums = SKIP
+	sha256sums = SKIP
+	sha256sums = SKIP
+
+pkgname = gatemon-git
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 /check_dhcp
 /*.deb
+/pkg/
+/src/
+/gatemon-git*.pkg.tar

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,0 +1,37 @@
+# Maintainer: Martin/Geno <geno+dev {at} fireorbit {dot} de>
+
+pkgname=gatemon-git
+_pkgname=gatemon
+_pkgauthor=FreifunkBremen
+pkgver=r37.615d977
+pkgrel=1
+pkgdesc=""
+arch=('any')
+url="https://github.com/${_pkgauthor}/${_pkgname}"
+license=('GPL3')
+depends=('monitoring-plugins' 'bind-tools' 'ndisc6')
+backup=('etc/check-all-vpn-exits.cfg')
+source=('check-all-vpn-exits.cfg' 'check-all-vpn-exits.sh'
+	'check-all-vpn-exits.service' 'check-all-vpn-exits.timer'
+	'Makefile' 'check_dhcp.c')
+sha256sums=('SKIP' 'SKIP'
+	'SKIP' 'SKIP'
+	'SKIP' 'SKIP')
+
+pkgver() {
+	# echo "$(git rev-list --count HEAD).$(git rev-parse --short HEAD)"
+	printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
+}
+
+build() {
+	make clean check_dhcp
+}
+
+package() {
+	install -Dm755 "check-all-vpn-exits.sh" "${pkgdir}/usr/local/bin/check-all-vpn-exists"
+	install -Dm755 "check_dhcp" "${pkgdir}/usr/local/bin/check_dhcp"
+	install -Dm600 "check-all-vpn-exits.cfg" "${pkgdir}/etc/check-all-vpn-exits.cfg"
+	install -Dm644 "check-all-vpn-exits.service" "${pkgdir}/usr/lib/systemd/system//check-all-vpn-exits.service"
+	install -Dm644 "check-all-vpn-exits.timer" "${pkgdir}/usr/lib/systemd/system//check-all-vpn-exits.timer"
+}
+

--- a/check-all-vpn-exits.cfg
+++ b/check-all-vpn-exits.cfg
@@ -5,6 +5,6 @@ MESHMON_PROVIDER='SET_PROVIDER_NAME_HERE'
 NETWORK_DEVICE='ffhb-mesh'
 
 # values below usually don't need to be changed:
-API_URL='http://status.bremen.freifunk.net/put.php'
+API_URL='https://status.bremen.freifunk.net/put.php'
 HOST_TO_FETCH='meineip.moritzrudert.de'
 VPN_NUMBER=6

--- a/check-all-vpn-exits.service
+++ b/check-all-vpn-exits.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Check all vpn exists (gatemon)
+After=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/check-all-vpn-exists
+TimeoutStopSec=300
+KillMode=process
+KillSignal=SIGINT
+
+[Install]
+WantedBy=multi-user.target

--- a/check-all-vpn-exits.sh
+++ b/check-all-vpn-exits.sh
@@ -1,7 +1,7 @@
 #! /usr/bin/env bash
 
 # Set path to a save default
-PATH="$(dirname "$0"):/usr/lib/gatemon/:/usr/lib/nagios/plugins:/bin:/usr/bin:/sbin:/usr/sbin"
+PATH="$(dirname "$0"):/usr/lib/gatemon/:/usr/lib/nagios/plugins:/usr/lib/monitoring-plugins:/bin:/usr/bin:/sbin:/usr/sbin"
 
 whitespace_awk() {
     SEP="$1"

--- a/check-all-vpn-exits.timer
+++ b/check-all-vpn-exits.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Check all vpn exists (gatemon) every 10min
+
+[Timer]
+OnBootSec=5min
+OnActiveSec=10min
+OnUnitActiveSec=10min
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
`check_dhcp` does not work yet, any idea?:
```
root@ffhb-arch ~ # setcap 'cap_net_bind_service=+ep' /usr/local/bin/check_dhcp
root@ffhb-arch ~ # /usr/local/bin/check_dhcp ens3 10.196.0.5
bind(outsock): Address already in use
Probably we are missing CAP_NET_BIND_SERVICE
```